### PR TITLE
Feature: pagination and query decorators.

### DIFF
--- a/src/utils/pagination/paginated-result.interface.ts
+++ b/src/utils/pagination/paginated-result.interface.ts
@@ -1,0 +1,15 @@
+export interface PaginatedResult <T> {
+  meta?: {
+    total?: number
+  }
+  items: T[]
+}
+
+export const emptyPaginatedResult = <T>(): PaginatedResult<T> => {
+  return {
+    items: [],
+    meta: {
+      total: 0
+    }
+  }
+}

--- a/src/utils/pagination/pagination.decorator.ts
+++ b/src/utils/pagination/pagination.decorator.ts
@@ -4,7 +4,7 @@ import { IsArray } from 'class-validator'
 
 class PaginatedEntityMeta {
   @ApiProperty()
-  readonly count: number
+  readonly total: number
 }
 class PaginatedEntity<T> {
   @IsArray()
@@ -15,9 +15,9 @@ class PaginatedEntity<T> {
   readonly meta: PaginatedEntityMeta
 }
 
-export const ApiPaginatedResponse = <T extends Type<unknown>>(entityType: T): MethodDecorator => {
+export const PaginationResponse = <T extends Type<unknown>>(entityType: T): MethodDecorator => {
   return applyDecorators(
-    ApiExtraModels(PaginatedEntity),
+    ApiExtraModels(PaginatedEntity, entityType),
     ApiOkResponse({
       description: 'pagination response',
       schema: {

--- a/src/utils/pagination/pagination.decorator.ts
+++ b/src/utils/pagination/pagination.decorator.ts
@@ -1,0 +1,38 @@
+import { applyDecorators, type Type } from '@nestjs/common'
+import { ApiExtraModels, ApiOkResponse, ApiProperty, getSchemaPath } from '@nestjs/swagger'
+import { IsArray } from 'class-validator'
+
+class PaginatedEntityMeta {
+  @ApiProperty()
+  readonly count: number
+}
+class PaginatedEntity<T> {
+  @IsArray()
+  @ApiProperty({ isArray: true })
+  readonly items: T[]
+
+  @ApiProperty({ type: PaginatedEntityMeta })
+  readonly meta: PaginatedEntityMeta
+}
+
+export const ApiPaginatedResponse = <T extends Type<unknown>>(entityType: T): MethodDecorator => {
+  return applyDecorators(
+    ApiExtraModels(PaginatedEntity),
+    ApiOkResponse({
+      description: 'pagination response',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(PaginatedEntity) },
+          {
+            properties: {
+              items: {
+                type: 'array',
+                items: { $ref: getSchemaPath(entityType) }
+              }
+            }
+          }
+        ]
+      }
+    })
+  )
+}

--- a/src/utils/query/paginated-search-query.dto.ts
+++ b/src/utils/query/paginated-search-query.dto.ts
@@ -1,0 +1,13 @@
+import { Type } from 'class-transformer'
+import { IsOptional, ValidateNested } from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+import { PaginationQuery } from './pagination-query.dto.js'
+import { SearchQuery } from './search-query.dto.js'
+
+export abstract class PaginatedSearchQuery extends SearchQuery {
+  @ApiProperty({ type: PaginationQuery })
+  @IsOptional()
+  @Type(() => PaginationQuery)
+  @ValidateNested()
+    pagination?: PaginationQuery
+}

--- a/src/utils/query/pagination-query.dto.ts
+++ b/src/utils/query/pagination-query.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Type } from 'class-transformer'
+import { IsInt, IsOptional, IsPositive, Max, Min } from 'class-validator'
+
+export class PaginationQuery {
+  @ApiProperty({ required: true })
+  @IsOptional()
+  @Type(() => Number)
+  @Max(100)
+  @IsPositive()
+  @IsInt()
+    limit?: number
+
+  @ApiProperty({ required: true })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(0)
+  @IsInt()
+    page?: number
+
+  get offset (): number | undefined {
+    if (this.page == null || this.limit == null) return undefined
+    return this.page * this.limit
+  }
+}

--- a/src/utils/query/query.decorator.ts
+++ b/src/utils/query/query.decorator.ts
@@ -1,0 +1,19 @@
+import { applyDecorators, type Type } from '@nestjs/common'
+import { ApiExtraModels, ApiQuery, getSchemaPath } from '@nestjs/swagger'
+
+export function PaginationQuery (query: Type<unknown>): MethodDecorator {
+  return applyDecorators(
+    ApiExtraModels(query),
+    ApiQuery({
+      required: false,
+      description: 'Pagination query, stringified object with optional pagination, sort, like and match',
+      name: 'q',
+      style: 'deepObject',
+      explode: true,
+      type: 'object',
+      schema: {
+        $ref: getSchemaPath(query)
+      }
+    })
+  )
+}

--- a/src/utils/query/search-query.dto.ts
+++ b/src/utils/query/search-query.dto.ts
@@ -1,0 +1,20 @@
+import { SortDirection } from './sort-direction.enum.js'
+
+export abstract class SortQuery {
+  [key: string]: undefined | SortDirection
+}
+
+export abstract class LikeQuery {
+  abstract key: unknown
+  abstract value: unknown
+}
+
+export abstract class MatchQuery {
+  [key: string]: unknown
+}
+
+export abstract class SearchQuery {
+  abstract sort?: SortQuery
+  abstract match?: MatchQuery
+  abstract like?: LikeQuery
+}

--- a/src/utils/query/sort-direction.enum.ts
+++ b/src/utils/query/sort-direction.enum.ts
@@ -1,0 +1,15 @@
+export enum SortDirection {
+  ASC = 'asc',
+  DESC = 'desc'
+}
+
+export function mapSortDirectionToTypeormOrder (direction: SortDirection): 'ASC' | 'DESC' {
+  switch (direction) {
+  case SortDirection.ASC: return 'ASC'
+  case SortDirection.DESC: return 'DESC'
+  }
+}
+
+export function mapSortDirectionOrUndefinedToTypeormOrder (direction: SortDirection | undefined): 'ASC' | 'DESC' | undefined {
+  return direction == null ? undefined : mapSortDirectionToTypeormOrder(direction)
+}

--- a/src/utils/query/transform-pagination.ts
+++ b/src/utils/query/transform-pagination.ts
@@ -1,0 +1,19 @@
+import { type PaginationQuery } from './pagination-query.dto.js'
+
+export interface TypeORMPaginationType {
+  skip: number
+  take: number
+}
+
+export function transformPaginationForTypeORM (
+  query?: PaginationQuery | null,
+  maxLimit = 25
+): TypeORMPaginationType {
+  const limit = Math.min(query?.limit ?? maxLimit, maxLimit)
+  const page = query?.page ?? 0
+
+  return {
+    skip: page * limit,
+    take: limit
+  }
+}


### PR DESCRIPTION
Auto generate documentation for query and paginated results based on types

Example usage:

```  
@Get()
@ApiOperation({
  summary: 'Get all the projects. (paginated data)'
})
@ApiPaginatedResponse(ProjectTransformerType)
@PaginationQuery(ProjectQuery)
async getProjects (@Query() q: ProjectQuery): Promise<void> {
}
```

Results in:
<img width="674" alt="image" src="https://github.com/wisemen-digital/nestjs-template/assets/43320258/d01ffcf4-2f58-434c-a7bf-0211786ee850">
<img width="742" alt="image" src="https://github.com/wisemen-digital/nestjs-template/assets/43320258/93f57c87-2fb2-4704-be9e-d08af89dac67">
